### PR TITLE
PosyArray improvements

### DIFF
--- a/gpkit/posyarray.py
+++ b/gpkit/posyarray.py
@@ -151,3 +151,15 @@ class PosyArray(np.ndarray):
     def sub(self, subs, val=None, allow_negative=False):
         "Substitutes into the array"
         return PosyArray([p.sub(subs, val, allow_negative) for p in self])
+
+    def right(self):
+        "Self, sampled one index up, with zeropad"
+        if self.ndim != 1:
+            raise NotImplementedError("not implemented for ndim=%s" % self.ndim)
+        return PosyArray(np.hstack((self[1:], 0)))
+
+    def left(self):
+        "Self, sampled one index down, with zeropad"
+        if self.ndim != 1:
+            raise NotImplementedError("not implemented for ndim=%s" % self.ndim)
+        return PosyArray(np.hstack((0, self[:-1])))

--- a/gpkit/posyarray.py
+++ b/gpkit/posyarray.py
@@ -152,14 +152,18 @@ class PosyArray(np.ndarray):
         "Substitutes into the array"
         return PosyArray([p.sub(subs, val, allow_negative) for p in self])
 
+    @property
     def right(self):
         "Self, sampled one index up, with zeropad"
         if self.ndim != 1:
-            raise NotImplementedError("not implemented for ndim=%s" % self.ndim)
+            raise NotImplementedError("not implemented for ndim = %s" %
+                                      self.ndim)
         return PosyArray(np.hstack((self[1:], 0)))
 
+    @property
     def left(self):
         "Self, sampled one index down, with zeropad"
         if self.ndim != 1:
-            raise NotImplementedError("not implemented for ndim=%s" % self.ndim)
+            raise NotImplementedError("not implemented for ndim = %s"
+                                      % self.ndim)
         return PosyArray(np.hstack((0, self[:-1])))

--- a/gpkit/posyarray.py
+++ b/gpkit/posyarray.py
@@ -94,7 +94,7 @@ class PosyArray(np.ndarray):
                 return PosyArray(l)
             else:
                 return PosyArray([e == other for e in self])
-        return PosyArray([e for e in self._eq(self, other)])
+        return PosyArray(self._eq(self, other))
 
     def __ne__(self, m):
         "Does type checking, then applies 'not ==' in a vectorized fashion."
@@ -114,7 +114,7 @@ class PosyArray(np.ndarray):
                 return PosyArray(l)
             else:
                 return PosyArray([e <= other for e in self])
-        return PosyArray([e for e in self._leq(self, other)])
+        return PosyArray(self._leq(self, other))
 
     _geq = np.vectorize(lambda a, b: a >= b)
 
@@ -128,7 +128,7 @@ class PosyArray(np.ndarray):
                 return PosyArray(l)
             else:
                 return PosyArray([e >= other for e in self])
-        return PosyArray([e for e in self._geq(self, other)])
+        return PosyArray(self._geq(self, other))
 
     def outer(self, other):
         "Returns the array and argument's outer product."

--- a/gpkit/tests/t_posy_array.py
+++ b/gpkit/tests/t_posy_array.py
@@ -71,8 +71,8 @@ class t_PosyArray(unittest.TestCase):
 
     def test_left_right(self):
         x = VectorVariable(10, 'x')
-        xL = x.left()
-        xR = x.right()
+        xL = x.left
+        xR = x.right
         self.assertEqual(xL[0], 0)
         self.assertEqual(xL[1], x[0])
         self.assertEqual(xR[-1], 0)

--- a/gpkit/tests/t_posy_array.py
+++ b/gpkit/tests/t_posy_array.py
@@ -69,6 +69,16 @@ class t_PosyArray(unittest.TestCase):
             constraints = (c == 1)
         self.assertEqual(len(constraints), 5)
 
+    def test_left_right(self):
+        x = VectorVariable(10, 'x')
+        xL = x.left()
+        xR = x.right()
+        self.assertEqual(xL[0], 0)
+        self.assertEqual(xL[1], x[0])
+        self.assertEqual(xR[-1], 0)
+        self.assertEqual(xR[0], x[1])
+        self.assertEqual((xL + xR)[1:-1], x[2:] + x[:-2])
+
 
 tests = [t_PosyArray]
 


### PR DESCRIPTION
* implement new convenience methods useful for finite-differencing `PosyArray`s

Example usage:
```python
from gpkit import VectorVariable
x = VectorVariable(10, 'x', 'm')
dx = VectorVariable(10, 'dx', 'm')
constraint = (x >= x.left + dx/2. + dx.left/2.)
```