### PR TITLE
Issue224 -- standardizing method names

### DIFF
--- a/docs/source/advancedcommands.rst
+++ b/docs/source/advancedcommands.rst
@@ -203,7 +203,7 @@ Example Usage
     import gpkit
     x = gpkit.Variable('x')
     y = gpkit.Variable('y')
-    gpkit.enable_signomials = True
+    gpkit.enable_signomials()
     sp = gpkit.SP(x, [x >= 1-y, y <= 0.1])
     sol = sp.localsolve(printing=False, solver=self.solver)
     self.assertAlmostEqual(sol["variables"]["x"], 0.9, self.ndig)
@@ -211,7 +211,7 @@ Example Usage
     sol = sp.localsolve(printing=False, solver=self.solver,
                         reltol=1e-4, xk={})
     self.assertAlmostEqual(sol["variables"]["x"], 0.9, self.ndig)
-    gpkit.enable_signomials = False
+    gpkit.disable_signomials()
 
 When using the ``localsolve`` method, the ``reltol`` argument specifies the relative tolerance of the solver: that is, by what percent does the solution have to improve between iterations? If any iteration improves less than that amount, the solver stops and returns its value.
 

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -17,7 +17,7 @@
 """
 
 
-def disableUnits():
+def disable_units():
     """Disables units support in a particular instance of GPkit.
 
     Posynomials created after calling this are incompatible with those created
@@ -41,7 +41,7 @@ def disableUnits():
     DimensionalityError = ValueError
 
 
-def enableUnits():
+def enable_units():
     """Enables units support in a particular instance of GPkit.
 
     Posynomials created after calling this are incompatible with those created
@@ -56,9 +56,9 @@ def enableUnits():
     except ImportError:
         print("Optional Python units library (Pint) not installed;"
               "unit support disabled.")
-        disableUnits()
+        disable_units()
 
-enableUnits()
+enable_units()
 
 _SIGNOMIALS_ENABLED = False
 

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -60,7 +60,20 @@ def enableUnits():
 
 enableUnits()
 
-enable_signomials = False
+_SIGNOMIALS_ENABLED = False
+
+
+def enable_signomials():
+    """Enables signomial support in a particular instance of GPkit."""
+    global _SIGNOMIALS_ENABLED
+    _SIGNOMIALS_ENABLED = True
+
+
+def disable_signomials():
+    """Disables signomial support in a particular instance of GPkit."""
+    global _SIGNOMIALS_ENABLED
+    _SIGNOMIALS_ENABLED = False
+
 
 from .nomials import Monomial, Posynomial, Signomial
 from .variables import Variable, VectorVariable

--- a/gpkit/nomials.py
+++ b/gpkit/nomials.py
@@ -104,8 +104,8 @@ class Signomial(object):
         else:
             any_negative = any((c <= 0 for c in cs))
         if any_negative:
-            from . import enable_signomials
-            if not enable_signomials and not allow_negative:
+            from . import _SIGNOMIALS_ENABLED
+            if not _SIGNOMIALS_ENABLED and not allow_negative:
                 raise ValueError("each c must be positive.")
         else:
             self.__class__ = Posynomial
@@ -366,25 +366,25 @@ class Signomial(object):
             return NotImplemented
 
     def __neg__(self):
-        from . import enable_signomials
+        from . import _SIGNOMIALS_ENABLED
 
-        if not enable_signomials:
+        if not _SIGNOMIALS_ENABLED:
             return NotImplemented
         else:
             return -1*self
 
     def __sub__(self, other):
-        from . import enable_signomials
+        from . import _SIGNOMIALS_ENABLED
 
-        if not enable_signomials:
+        if not _SIGNOMIALS_ENABLED:
             return NotImplemented
         else:
             return self + -other
 
     def __rsub__(self, other):
-        from . import enable_signomials
+        from . import _SIGNOMIALS_ENABLED
 
-        if not enable_signomials:
+        if not _SIGNOMIALS_ENABLED:
             return NotImplemented
         else:
             return other + -self
@@ -443,9 +443,9 @@ class Constraint(Posynomial):
     def __init__(self, p1, p2):
         p1 = Signomial(p1)
         p2 = Signomial(p2)
-        from . import enable_signomials
+        from . import _SIGNOMIALS_ENABLED
 
-        if enable_signomials and not isinstance(p2, Monomial):
+        if _SIGNOMIALS_ENABLED and not isinstance(p2, Monomial):
             p = p1 - p2 + 1
         else:
             p = p1 / p2
@@ -462,7 +462,7 @@ class Constraint(Posynomial):
 
         for i, exp in enumerate(p.exps):
             if not exp:
-                if not enable_signomials:
+                if not _SIGNOMIALS_ENABLED:
                     if p.cs[i] < 1:
                         coeff = float(1 - p.cs[i])
                         p.cs = np.hstack((p.cs[:i], p.cs[i+1:]))

--- a/gpkit/tests/run_tests.py
+++ b/gpkit/tests/run_tests.py
@@ -42,7 +42,7 @@ def run(xmloutput=False):
 
     print "\n#################################################################"
     print "Running with units disabled:"
-    gpkit.disableUnits()
+    gpkit.disable_units()
 
     if xmloutput:
         xmlrunner.XMLTestRunner(output='test_reports_nounits').run(suite)

--- a/gpkit/tests/simpleflight.py
+++ b/gpkit/tests/simpleflight.py
@@ -8,7 +8,7 @@ class simpleflight_generator(object):
 
     def __init__(self, disableUnits=False):
         if disableUnits:
-            gpkit.disableUnits()
+            gpkit.disable_units()
             if gpkit.units:
                 raise RuntimeWarning
 

--- a/gpkit/tests/t_geometric_program.py
+++ b/gpkit/tests/t_geometric_program.py
@@ -108,10 +108,10 @@ class t_GP(unittest.TestCase):
     def test_zeroing(self):
         L = Variable("L")
         k = gpkit.Variable("k", 0)
-        gpkit.enable_signomials = True
+        gpkit.enable_signomials()
         sol = GP(1/L, [L-5*k <= 10]).solve(printing=False, solver=self.solver)
         self.assertAlmostEqual(sol(L), 10, self.ndig)
-        gpkit.enable_signomials = False
+        gpkit.disable_signomials()
 
     def test_CO(self):
         L = Variable("L")
@@ -132,17 +132,17 @@ class t_SP(unittest.TestCase):
     def test_trivial_sp(self):
         x = Variable('x')
         y = Variable('y')
-        gpkit.enable_signomials = True
+        gpkit.enable_signomials()
         sp = gpkit.SP(x, [x >= 1-y, y <= 0.1])
         sol = sp.localsolve(printing=False, solver=self.solver)
         self.assertAlmostEqual(sol["variables"]["x"], 0.9, self.ndig)
         sp = gpkit.SP(x, [x >= 0.1, x+y >= 1, y <= 0.1])
         sol = sp.localsolve(printing=False, solver=self.solver)
         self.assertAlmostEqual(sol["variables"]["x"], 0.9, self.ndig)
-        gpkit.enable_signomials = False
+        gpkit.disable_signomials()
 
     def test_united_interp(self):
-        gpkit.enable_signomials = True
+        gpkit.enable_signomials()
         L = Variable("L", "m", "Length")
         W = Variable("W", "m", "Width")
         Obj = Variable("Obj", "1/m^4", "Objective")
@@ -159,10 +159,10 @@ class t_SP(unittest.TestCase):
             sol = sp.localsolve(printing=False, solver=self.solver)
             solv = sol["variables"]
             self.assertAlmostEqual(solv["L"][3], 3.276042, 5)
-        gpkit.enable_signomials = False
+        gpkit.disable_signomials()
 
     def test_issue180(self):
-        gpkit.enable_signomials = True
+        gpkit.enable_signomials()
         L = Variable("L")
         Lmax = gpkit.Variable("L_{max}", 10)
         W = Variable("W")
@@ -177,7 +177,7 @@ class t_SP(unittest.TestCase):
                 Obj >= a*(2*L + 2*W) + (1-a)*(12 * W**-1 * L**-3)]
         sp = SP(Obj, eqns)
         spsol = sp.localsolve(printing=False)
-        gpkit.enable_signomials = False
+        gpkit.disable_signomials()
         # now solve as GP
         eqns[-1] = (Obj >= a_val*(2*L + 2*W) + (1-a_val)*(12 * W**-1 * L**-3))
         gp = GP(Obj, eqns)

--- a/gpkit/tests/t_nomials.py
+++ b/gpkit/tests/t_nomials.py
@@ -1,7 +1,7 @@
 import math
 import unittest
 from gpkit import Monomial, Posynomial, Signomial
-import gpkit
+from gpkit import enable_signomials, disable_signomials
 
 
 class t_Monomial(unittest.TestCase):
@@ -153,10 +153,10 @@ class t_Signomial(unittest.TestCase):
     def test_init(self):
         x = Monomial('x')
         y = Monomial('y')
-        gpkit.enable_signomials = True
+        enable_signomials()
         self.assertEqual(str(1 - x - y**2 - 1), "-x + -y**2")
         self.assertEqual((1 - x/y**2)._latex(), "-\\frac{x}{y^{2}} + 1")
-        gpkit.enable_signomials = False
+        disable_signomials()
         self.assertRaises(TypeError, lambda: x-y)
 
 


### PR DESCRIPTION
As discussed in #224,

* rename function `enableUnits()` --> `enable_units()`
* rename function `disableUnits()` --> `disable_units()`
* create functions `enable_signomials()` and `disable_signomials()`, to replace current practice of modifying the module-level boolean variable `gpkit.enable_signomials`.