### PR TITLE
simple hotfix for #296; and add more cost testing

### DIFF
--- a/gpkit/_mosek/cli_expopt.py
+++ b/gpkit/_mosek/cli_expopt.py
@@ -112,24 +112,6 @@ def imize_fn(filename):
         shutil.rmtree(folder, ignore_errors=False,
                       onerror=errorRemoveReadonly)
 
-        try:
-            Ad = A.tocoo().todense() # dense A
-            nmons = sum(p_idxs == 0) # number of monomials in objective function
-
-            # if there is a constant term in the objective function
-            if (Ad[range(nmons), :].sum(axis=1) == 0).any():
-                # In the case of a constant in the obj function, recalculates
-                # the optimal cost using the primal and the objective function
-                J = Ad.shape[1]
-                objective_val = 0
-                for i in range(nmons):
-                    obj1 = 1
-                    for j in range(J):
-                        obj1 = obj1*exp(primal_vals[j])**Ad[i,j]
-                    objective_val += c[i]*obj1
-        except TypeError:
-            pass
-
         return dict(status="optimal",
                     objective=objective_val,
                     primal=primal_vals,

--- a/gpkit/_mosek/expopt.py
+++ b/gpkit/_mosek/expopt.py
@@ -244,26 +244,6 @@ def imize(c, A, p_idxs, k):
     MSK._deleteenv(ptr(env))
 
     status = MSK._SOL_STA_LOOKUPTABLE[solsta.value]
-
-    try:
-        Ad = A.tocoo().todense() # dense A
-        nmons = sum(p_idxs == 0) # number of monomials in objective function
-
-        # if there is a constant term in the objective function
-        if (Ad[range(nmons), :].sum(axis=1) == 0).any():
-            # In the case of a constant in the obj function, recalculates
-            # the optimal cost using the primal and the objective function
-            J = Ad.shape[1]
-            objval.value = 0
-            dvs = list(xx)
-            for i in range(nmons):
-                obj1 = 1
-                for j in range(J):
-                    obj1 = obj1*exp(dvs[j])**Ad[i,j]
-                objval.value += c[i]*obj1
-    except TypeError:
-        pass
-
     return dict(status=status,
                 objective=objval.value,
                 primal=list(xx),

--- a/gpkit/geometric_program.py
+++ b/gpkit/geometric_program.py
@@ -531,7 +531,8 @@ class GeometricProgram(Model):
         #        raise RuntimeWarning("constraint exceeded:"
         #                             " %s = 1 + %0.2e" % (p, val-1))
 
-        if "objective" in result:
+        if "objective" in result and "mosek" not in self.solver:
+            # TODO remove mosek conditional -- issue # 296
             cost = float(result["objective"])
         else:
             cost = self.cost.subcmag(variables)


### PR DESCRIPTION
This is a pull request to update `fix_296`, i.e. #304.
 - Simplifies cost computation hotfix by doing it in `GeometricProgram._parse_result`
 - Adds more cost testing to existing tests
 - Updates logic for number of accuracy digits in GP testing