### PR TITLE
first feasibility reports

### DIFF
--- a/gpkit/geometric_program.py
+++ b/gpkit/geometric_program.py
@@ -182,13 +182,11 @@ class GeometricProgram(object):
         else:
             return result
 
-    def feasibility_search(self, varname=None, flavour="max", *args, **kwargs):
+    def feasibility_search(self, flavour="max", varname=None, *args, **kwargs):
         """Returns a new GP for the closest feasible point of the current GP.
 
         Arguments
         ---------
-        varname : str
-            LaTeX name of slack variables.
         flavour : str
             Specifies the objective function minimized in the search:
 
@@ -200,6 +198,9 @@ class GeometricProgram(object):
                         the product of those slacks. Useful for identifying the
                         most problematic constraints. Described in Eqn. 11
                         of [Boyd2007]
+
+        varname : str
+            LaTeX name of slack variables.
 
         *args, **kwargs
             Passed on to GP initialization.

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -409,9 +409,9 @@ class Model(object):
         m, _ = self.formProgram("sp", self.signomials, self.constants, verbosity)
         return m
 
-    def feasible(self,
-                 search=["overall", "constraints", "constants"],
-                 constvars=None, verbosity=0):
+    def feasibility(self,
+                    search=["overall", "constraints", "constants"],
+                    constvars=None, verbosity=0):
         """Searches for feasibile versions of the Model.
 
         Argument
@@ -448,7 +448,7 @@ class Model(object):
         >>> x_max = Variable("x_max", 1)
         >>> m = Model(x, [x <= x_max, x >= x_min])
         >>> # m.solve()  # RuntimeWarning!
-        >>> feas = m.feasible
+        >>> feas = m.feasibility()
         >>>
         >>> # USING OVERALL
         >>> m.constraints = PosyArray(m.signomials)/feas["overall"]


### PR DESCRIPTION
closes #31

Example usage:
```python
In [3]: %paste
from gpkit import Variable, Model
x = Variable("x")
x_min = Variable("x_min", 2)
x_max = Variable("x_max", 1)
m = Model(x, [x <= x_max, x >= x_min])
#m.solve()
m.feasibility_report()

## -- End pasted text --
Infeasibility
-------------
      overall : 1.41
   constraint : [2.0, 1.0]
     constant : {x_min: 1.0}
Out[3]: 
{'constants': {x_min: 1.0},
 'constraints': [2.0, 1.0],
 'overall': 1.414213562373095}
```

The `overall` infeasibility is the number each constraint's less-than side would have to be divided by to make the program feasible. The `constraints` infeasibilities are similar, but specific to each constraint. The `constant` infeasibilities are a set of substitutions that would make the problem feasible, so they're really more a set of "feasibilities".