### PR TITLE
Added Embeddable Build Status

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Build Status](https://acdl.mit.edu/csi/buildStatus/icon?job=gpkit_Push)](https://acdl.mit.edu/csi/job/gpkit_Push/)
 [<img src="http://gpkit.rtfd.org/en/latest/_images/gplogo.png" width=110 alt="GPkit" />](http://gpkit.readthedocs.org/)
 
 **[Documentation](http://gpkit.readthedocs.org/)** | [Install instructions](http://gpkit.readthedocs.org/en/latest/installation.html) | [Examples](http://gpkit.readthedocs.org/en/latest/examples.html) | [Glossary](http://gpkit.readthedocs.org/en/latest/glossary.html) | [Citing GPkit](http://gpkit.readthedocs.org/en/latest/citinggpkit.html)


### PR DESCRIPTION
This should add an embedded build status to the main page (I think). Someone needs to push a commit directly to master to test the build.