### PR TITLE
Monomial equality refactor

### DIFF
--- a/gpkit/nomials.py
+++ b/gpkit/nomials.py
@@ -225,12 +225,7 @@ class Signomial(NomialData):
     def __ne__(self, other):
         return not super(Signomial, self).__eq__(other)
 
-    # constraint generation
     def __eq__(self, other):
-        # if at least one is a monomial, return a constraint
-        mons = Numbers + (Monomial,)
-        if isinstance(other, mons) and isinstance(self, mons):
-            return MonoEQConstraint(self, other)
         return super(Signomial, self).__eq__(other)
 
     def __le__(self, other):
@@ -502,6 +497,22 @@ class Monomial(Posynomial):
             return Monomial(self.exp*other, self.c**other)
         else:
             return NotImplemented
+
+    def __ne__(self, other):
+        "Inequality test"
+        if isinstance(other, Numbers):
+            # numeric comparison
+            return bool(self.exp) or self.value != other
+        return super(Monomial, self).__ne__(other)
+
+    def __eq__(self, other):
+        mons = Numbers + (Monomial,)
+        if isinstance(other, mons):
+            # if both are monomials, return a constraint
+            return MonoEQConstraint(self, other)
+        # fall back on Monomial __ne__ for boolean comparison
+        return not self.__ne__(other)
+
 
     # Monomial.__le__ falls back on Posynomial.__le__
 

--- a/gpkit/tests/t_nomials.py
+++ b/gpkit/tests/t_nomials.py
@@ -106,6 +106,13 @@ class TestMonomial(unittest.TestCase):
         self.assertNotEqual(m1, m3)
         self.assertNotEqual(m1, m4)
 
+        # numeric
+        self.assertEqual(Monomial(3), 3)
+        self.assertEqual(Monomial(3), Monomial(3))
+        self.assertNotEqual(Monomial(3), 2)
+        self.assertNotEqual(Monomial('x'), 3)
+        self.assertNotEqual(Monomial(3), Monomial('x'))
+
     def test_div(self):
         "Test Monomial division"
         x = Monomial('x')


### PR DESCRIPTION
Idea is that Monomial should deal with equality/inequality testing with numeric types...

Could alternatively implement comparison of `NomialData` with numeric types...

Currently fails unit tests, `Monomial.__ne__` is not implemented and falls back on an incorrect implementation by a parent.