### PR TITLE
implement fromnomials for NomialData construction

### DIFF
--- a/gpkit/geometric_program.py
+++ b/gpkit/geometric_program.py
@@ -48,7 +48,7 @@ class GeometricProgram(NomialData):
         self.constraints = constraints
         self.posynomials = [cost] + list(constraints)
         # init NomialData to create self.exps, self.cs, and so on
-        super(GeometricProgram, self).__init__(nomials=self.posynomials)
+        super(GeometricProgram, self).init_from_nomials(self.posynomials)
         if self.any_nonpositive_cs:
             raise ValueError("GeometricPrograms cannot contain Signomials.")
         if [v for v in self.values.values() if not is_sweepvar(v)]:

--- a/gpkit/model.py
+++ b/gpkit/model.py
@@ -239,7 +239,7 @@ class Model(object):
     @property
     def beforesubs(self):
         "Get this Model's NomialData before any substitutuions"
-        return NomialData(nomials=self.signomials)
+        return NomialData.fromnomials(self.signomials)
 
     @property
     def allsubs(self):
@@ -252,7 +252,7 @@ class Model(object):
     def signomials_et_al(self):
         "Get signomials, beforesubs, allsubs in one pass; applies VarKey subs."
         signomials = self.signomials
-        beforesubs = NomialData(nomials=signomials)
+        beforesubs = NomialData.fromnomials(signomials)
         allsubs = beforesubs.values
         allsubs.update(self.substitutions)
         varkeysubs = {vk: nvk for vk, nvk in allsubs.items()

--- a/gpkit/nomial_data.py
+++ b/gpkit/nomial_data.py
@@ -56,7 +56,8 @@ class NomialData(object):
         """Way to initialize from nomials. Calls __init__.
         Used by subclass __init__ methods.
         """
-        exps, cs = exps_and_cs_from_nomials(nomials)
+        exps = functools_reduce(add, (tuple(s.exps) for s in nomials))
+        cs = np.hstack((mag(s.cs) for s in nomials))
         # nomials are already simplified, so simplify=False
         NomialData.__init__(self, exps, cs, simplify=False)
         self.nomials = nomials  # TODO eliminate constructor-dependent state
@@ -134,13 +135,6 @@ class NomialData(object):
         if self.units != other.units:
             return False
         return True
-
-
-def exps_and_cs_from_nomials(nomials):
-    "Flatten an iterable of nomials into exps and cs"
-    exps = functools_reduce(add, (tuple(s.exps) for s in nomials))
-    cs = np.hstack((mag(s.cs) for s in nomials))
-    return exps, cs
 
 
 def simplify_exps_and_cs(exps, cs, return_map=False):

--- a/gpkit/nomial_data.py
+++ b/gpkit/nomial_data.py
@@ -19,18 +19,11 @@ class NomialData(object):
     varlocs: {VarKey: list} (terms each variable appears in)
     units: pint.UnitsContainer
     """
-    def __init__(self, exps=None, cs=None, nomials=None, simplify=True):
-        if nomials and (exps or cs):
-            raise ValueError("The NomialData initializor accepts either"
-                             " exps and cs, or nomials, but not both.")
-        elif nomials:
-            self.nomials = nomials
-            exps = functools_reduce(add, (tuple(s.exps) for s in nomials))
-            cs = np.hstack((mag(s.cs) for s in nomials))
-            simplify = False  # nomials have already been simplified
-        elif exps is None or cs is None:
-            raise ValueError("creation of a NomialData requires exps and cs.")
-
+    def __init__(self, exps=None, cs=None, simplify=True):
+        if exps is None and cs is None:
+            # pass through for classmethods to get a NomialData object,
+            # which they will then call __init__ on
+            return
         if simplify:
             exps, cs = simplify_exps_and_cs(exps, cs)
         self.exps, self.cs = exps, cs
@@ -38,9 +31,7 @@ class NomialData(object):
         self.varlocs, self.varstrs = locate_vars(self.exps)
         self.values = {vk: vk.descr["value"] for vk in self.varlocs
                        if "value" in vk.descr}
-        if nomials:
-            self.units = tuple(s.units for s in nomials)
-        elif isinstance(self.cs, Quantity):
+        if isinstance(self.cs, Quantity):
             self.units = Quantity(1, self.cs.units)
         else:
             self.units = None
@@ -53,6 +44,23 @@ class NomialData(object):
             assert len(self.exps) == len(self.cs)
             self._hashvalue = hash(tuple(zip(self.exps, self.cs)))
         return self._hashvalue
+
+    @classmethod
+    def fromnomials(cls, nomials):
+        """Construct a NomialData from an iterable of Signomial objects"""
+        nd = cls()  # use pass-through version of __init__
+        nd.init_from_nomials(nomials)
+        return nd
+
+    def init_from_nomials(self, nomials):
+        """Way to initialize from nomials. Calls __init__.
+        Used by subclass __init__ methods.
+        """
+        exps, cs = exps_and_cs_from_nomials(nomials)
+        # nomials are already simplified, so simplify=False
+        NomialData.__init__(self, exps, cs, simplify=False)
+        self.nomials = nomials  # TODO eliminate constructor-dependent state
+        self.units = tuple(s.units for s in nomials)
 
     def __repr__(self):
         return "gpkit.%s(%s)" % (self.__class__.__name__, hash(self))
@@ -82,7 +90,7 @@ class NomialData(object):
         if hasattr(self, "nomials"):
             subbed_nomials = [n.sub(substitutions, val, require_positive)
                               for n in self.nomials]
-            nd = NomialData(nomials=subbed_nomials)
+            nd = NomialData.fromnomials(subbed_nomials)
         else:
             _, exps, cs, _ = substitution(self, substitutions, val)
             nd = NomialData(exps, cs)
@@ -126,6 +134,13 @@ class NomialData(object):
         if self.units != other.units:
             return False
         return True
+
+
+def exps_and_cs_from_nomials(nomials):
+    "Flatten an iterable of nomials into exps and cs"
+    exps = functools_reduce(add, (tuple(s.exps) for s in nomials))
+    cs = np.hstack((mag(s.cs) for s in nomials))
+    return exps, cs
 
 
 def simplify_exps_and_cs(exps, cs, return_map=False):


### PR DESCRIPTION
This is a first stab at the type of changes needed under #446. There is a little awkwardness due to the fact that GeometricProgram implements a different `__init__` signature than `NomialData` (which it inherits from), but this PR gets around that issue.