### PR TITLE
unbreak MonoEQConstraint printing, resolves #462

### DIFF
--- a/gpkit/nomials.py
+++ b/gpkit/nomials.py
@@ -611,6 +611,9 @@ class MonoEQConstraint(Constraint):
         self.leq = m1/m2
         self.geq = m2/m1
 
+        self.left = m1
+        self.right = m2
+
     def __nonzero__(self):
         # a constraint not guaranteed to be satisfied
         # evaluates as "False"

--- a/gpkit/tests/t_constraints.py
+++ b/gpkit/tests/t_constraints.py
@@ -94,6 +94,13 @@ class TestMonoEQConstraint(unittest.TestCase):
         # try to initialize a Posynomial Equality constraint
         self.assertRaises(TypeError, MonoEQConstraint, x*y, x + y)
 
+    def test_str(self):
+        "Test that MonoEQConstraint.__str__ returns a string"
+        x = Variable('x')
+        y = Variable('y')
+        mec = (x == y)
+        self.assertEqual(type(str(mec)), str)
+
 
 class TestSignomialConstraint(unittest.TestCase):
     """Test Signomial constraints"""


### PR DESCRIPTION
This is a (very small) subset of f59f008bd4d4e84889025f08258176cb1eefe, plus a test, to fix #462. @bqpd or @pgkirsch, please either one of you go ahead and merge this if you are happy, assuming it passes Jenkins (it will fail El Capitan testing, which should not prevent merging).