### PR TITLE
allow tweaking modelname printing in latex

### DIFF
--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -156,3 +156,4 @@ def load_settings(path=SETTINGS_PATH):
         settings_ = {"installed_solvers": [""]}
     return settings_
 settings = load_settings()
+settings["latex_modelname"] = False

--- a/gpkit/__init__.py
+++ b/gpkit/__init__.py
@@ -156,4 +156,4 @@ def load_settings(path=SETTINGS_PATH):
         settings_ = {"installed_solvers": [""]}
     return settings_
 settings = load_settings()
-settings["latex_modelname"] = False
+settings["latex_modelname"] = True

--- a/gpkit/varkey.py
+++ b/gpkit/varkey.py
@@ -92,7 +92,9 @@ class VarKey(object):
 
     def latex(self):
         s = self.name
-        for subscript in ["idx", "model"]:
+        from . import settings
+        subscripts = ["idx"]+(["model"] if settings["latex_modelname"] else [])
+        for subscript in subscripts:
             if subscript in self.descr:
                 s = "{%s}_{%s}" % (s, self.descr[subscript])
                 if subscript == "idx":


### PR DESCRIPTION
```python
import gpkit
x = gpkit.Variable("x", model="test")
x  # prints without modelname
gpkit.settings["latex_modelname"] = True
x  # prints with modelname
```