### PR TITLE
better unit-mismatch-during-sub error message

### DIFF
--- a/gpkit/substitution.py
+++ b/gpkit/substitution.py
@@ -186,8 +186,11 @@ def substitution(nomial, substitutions, val=None):
                         new_units = var.units/sub.units
                         cs_[i] *= new_units.to('dimensionless')
                     except DimensionalityError:
-                        raise ValueError("substituted variables need the same"
-                                         " units as variables they replace.")
+                        raise ValueError("units of the substituted variable"
+                                         " '%s' [%s] are not compatible with"
+                                         " those of the original '%s' [%s]." %
+                                         (sub, sub.units.units,
+                                          var, var.units.units))
                 exps_[i] += HashVector({sub: x})
                 varlocs_[sub].append(i)
             elif isinstance(sub, Monomial):
@@ -196,8 +199,11 @@ def substitution(nomial, substitutions, val=None):
                         new_units = var.units/sub.units
                         cs_[i] *= new_units.to('dimensionless')
                     except DimensionalityError:
-                        raise ValueError("substituted monomials need the same"
-                                         " units as monomials they replace.")
+                        raise ValueError("units of the substituted monomial"
+                                         " '%s' [%s] are not compatible with"
+                                         " those of the original '%s' [%s]." %
+                                         (sub, sub.units.units,
+                                          var, var.units.units))
                 exps_[i] += x*sub.exp
                 cs_[i] *= mag(sub.c)**x
                 for subvar in sub.exp:


### PR DESCRIPTION
```
In [1]: import gpkit
In [2]: x = gpkit.Variable("x", "m")
In [3]: y = gpkit.Variable("y", "volt")
In [4]: x.sub(x, y)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
[...]
/home/eburn/projects/src/gpkit/gpkit/substitution.pyc in substitution(nomial, substitutions, val)
    204                                          " those of the original '%s' [%s]." %
    205                                          (sub, sub.units.units,
--> 206                                           var, var.units.units))
    207                 exps_[i] += x*sub.exp
    208                 cs_[i] *= mag(sub.c)**x

ValueError: units of the substituted monomial 'y [V]' [volt] are not compatible with those of the original 'x' [meter].

In [5]: x.sub(x, y.key)
---------------------------------------------------------------------------
ValueError                                Traceback (most recent call last)
[...]
/home/eburn/projects/src/gpkit/gpkit/substitution.pyc in substitution(nomial, substitutions, val)
    191                                          " those of the original '%s' [%s]." %
    192                                          (sub, sub.units.units,
--> 193                                           var, var.units.units))
    194                 exps_[i] += HashVector({sub: x})
    195                 varlocs_[sub].append(i)

ValueError: units of the substituted variable 'y' [volt] are not compatible with those of the original 'x' [meter].
```